### PR TITLE
docs: correct logging setup docstring

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 
 def setup_sentry_logging() -> None:
     """
-    Setup logging configuration for the application.
+    Set up logging configuration for the application.
     """
     sentry_logger = LoggingIntegration(
         level=logging.INFO,  # Capture info and above as breadcrumbs


### PR DESCRIPTION
## Summary
- fix grammar in logging setup docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cd30392d8832eaa1db8142d41aa07