### PR TITLE
refactor: consolidate logger messages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,12 +45,12 @@ def create_app() -> FastAPI:
             # Capture the exception in Sentry before handling it
             sentry_sdk.capture_exception(exc)
 
-        uvicorn_logger.error(
-            f"Unhandled exception occurred: {type(exc).__name__}: {str(exc)}\n"
-            f"Request URL: {request.url}\n"
-            f"Request method: {request.method}\n"
-            f"Traceback:\n{traceback.format_exc()}"
-        )
+        uvicorn_logger.error("\n".join([
+            f"Unhandled exception occurred: {type(exc).__name__}: {str(exc)}",
+            f"Request URL: {request.url}",
+            f"Request method: {request.method}",
+            f"Traceback:\n{traceback.format_exc()}",
+        ]))
         return JSONResponse(
             status_code=500,
             content={
@@ -74,11 +74,11 @@ def create_app() -> FastAPI:
                 })
             sentry_sdk.capture_exception(exc)
 
-        uvicorn_logger.warning(
-            f"HTTP exception: {exc.status_code} - {exc.detail}\n"
-            f"Request URL: {request.url}\n"
-            f"Request method: {request.method}"
-        )
+        uvicorn_logger.warning("\n".join([
+            f"HTTP exception: {exc.status_code} - {exc.detail}",
+            f"Request URL: {request.url}",
+            f"Request method: {request.method}",
+        ]))
         return JSONResponse(
             status_code=exc.status_code,
             content={
@@ -93,11 +93,11 @@ def create_app() -> FastAPI:
     async def validation_exception_handler(
         request: Request, exc: RequestValidationError
     ):
-        uvicorn_logger.warning(
-            f"Validation error: {str(exc)}\n"
-            f"Request URL: {request.url}\n"
-            f"Request method: {request.method}"
-        )
+        uvicorn_logger.warning("\n".join([
+            f"Validation error: {str(exc)}",
+            f"Request URL: {request.url}",
+            f"Request method: {request.method}",
+        ]))
         return JSONResponse(
             status_code=422,
             content={


### PR DESCRIPTION
## Summary
- combine exception handler log messages into single string

## Testing
- `python -m py_compile app/__init__.py`
- `python - <<'PY'
import logging
from app import create_app
from fastapi.testclient import TestClient

logging.basicConfig(level=logging.INFO)
app = create_app()

@app.get('/items/{item_id}')
async def read_item(item_id: int):
    return {'item_id': item_id}

client = TestClient(app)

print('Triggering global exception:')
try:
    client.get('/test-error')
except Exception:
    pass

print('Triggering HTTP exception:')
client.get('/nonexistent')

print('Triggering validation exception:')
client.get('/items/abc')
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd4277a18832ebc20ecad93ed1472