### PR TITLE
Add health endpoint integration test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    """Create a new FastAPI app instance for testing."""
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    """Return a TestClient for the FastAPI app."""
+    return TestClient(app)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,7 @@
+from fastapi.testclient import TestClient
+
+
+def test_health_endpoint(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "service": "fast-food-api"}


### PR DESCRIPTION
## Summary
- test `/health` endpoint for 200 response and expected payload
- provide TestClient fixtures for FastAPI app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd4283e74832e8a734300dd7aebf1